### PR TITLE
add JSX, GWT, SharpNative, Babel.js

### DIFF
--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -91,12 +91,6 @@
   url: 'https://github.com/afrog33k/SharpNative'
 ,
   # Compiled to JavaScript
-  name: 'Babel.js React preset'
-  source: 'JSX'
-  target: 'JavaScript'
-  type: 'Transpiler'
-  url: 'http://babeljs.io/docs/plugins/preset-react/'
-,
   name: 'Bridge.NET'
   source: 'C#'
   target: 'JavaScript'
@@ -204,12 +198,6 @@
   target: 'JavaScript'
   type: 'Transpiler'
   url: 'http://www.jsweet.org/'
-,
-  name: 'JSX'
-  source: 'JSX'
-  target: 'JavaScript'
-  type: 'Transpiler'
-  url: 'https://github.com/jsx/JSX'
 ,
   name: 'Kotlin JavaScript Compiler'
   source: 'Kotlin'

--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -84,7 +84,19 @@
   type: 'Transpiler'
   url: 'http://nim-lang.org/'
 ,
+  name: 'SharpNative'
+  source: 'C#'
+  target: 'D'
+  type: 'Transpiler'
+  url: 'https://github.com/afrog33k/SharpNative'
+,
   # Compiled to JavaScript
+  name: 'Babel.js React preset'
+  source: 'JSX'
+  target: 'JavaScript'
+  type: 'Transpiler'
+  url: 'http://babeljs.io/docs/plugins/preset-react/'
+,
   name: 'Bridge.NET'
   source: 'C#'
   target: 'JavaScript'
@@ -151,6 +163,12 @@
   type: 'Transpiler'
   url: 'https://github.com/ghcjs'
 ,
+  name: 'GWT'
+  source: 'Java'
+  target: 'JavaScript'
+  type: 'Transpiler'
+  url: 'http://www.gwtproject.org/'
+,
   name: 'Haste'
   source: 'Haskell'
   target: 'JavaScript'
@@ -186,6 +204,12 @@
   target: 'JavaScript'
   type: 'Transpiler'
   url: 'http://www.jsweet.org/'
+,
+  name: 'JSX'
+  source: 'JSX'
+  target: 'JavaScript'
+  type: 'Transpiler'
+  url: 'https://github.com/jsx/JSX'
 ,
   name: 'Kotlin JavaScript Compiler'
   source: 'Kotlin'


### PR DESCRIPTION
The GWT link could be the more specific http://www.gwtproject.org/doc/latest/DevGuideCompilingAndDebugging.html#DevGuideJavaToJavaScriptCompiler, but I'm not sure if such deep links fit well with the current ones (see #3 for a similar question).
