### PR TITLE
add the Grumpy (Python to Go) compiler

### DIFF
--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -6,6 +6,12 @@
   type: 'Transpiler'
   url: 'https://www.haskell.org/ghc/'
 ,
+  name: 'Grumpy'
+  source: 'Python'
+  target: 'Go'
+  type: 'Transpiler'
+  url: 'https://github.com/google/grumpy'
+,
   name: 'Haxe ActionScript Compiler'
   source: 'Haxe'
   target: 'ActionScript'


### PR DESCRIPTION
This was just announced in the Google Open Source Blog: https://opensource.googleblog.com/2017/01/grumpy-go-running-python.html

The link included here points to the main repository page, but as described in https://github.com/google/grumpy#method-2-grumpc, the actual compiler is https://github.com/google/grumpy/blob/master/tools/grumpc, so we could link to it instead.