### PR TITLE
Add js_of_ocaml

### DIFF
--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -508,6 +508,12 @@
   type: 'Transpiler'
   url: 'https://github.com/PiotrDabkowski/Js2Py'
 ,
+  name: 'Js_of_ocaml'
+  source: 'OCaml'
+  target: 'JavaScript'
+  type: 'Transpiler'
+  url: 'http://ocsigen.org/js_of_ocaml/'
+,
   name: 'JSIL'
   source: 'CIL'
   target: 'JavaScript'

--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -512,7 +512,7 @@
   source: 'OCaml'
   target: 'JavaScript'
   type: 'Transpiler'
-  url: 'http://ocsigen.org/js_of_ocaml/'
+  url: 'https://ocsigen.org/js_of_ocaml/'
 ,
   name: 'JSIL'
   source: 'CIL'


### PR DESCRIPTION
Js_of_ocaml is technically from OCaml *bytecode* to javascript (the ocaml compile can compile to both machine code and bytecode). But I think for the purpose of this graph, it doesn't matter much.