### PR TITLE
Add Apache Royale, update for Haxe

### DIFF
--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -145,6 +145,12 @@
   type: 'Intermediate'
   url: 'http://groovy-lang.org/groovyc.html'
 ,
+  name: 'Haxe ABC Compiler'
+  source: 'Haxe'
+  target: 'ActionScript Bytecode'
+  type: 'Intermediate'
+  url: 'https://haxe.org/'
+,
   name: 'IronPython'
   source: 'Python'
   target: 'CIL'
@@ -228,6 +234,12 @@
   target: 'CIL'
   type: 'Intermediate'
   url: 'https://github.com/dotnet/roslyn'
+,
+  name: 'Royale ABC Compiler'
+  source: 'ActionScript'
+  target: 'ActionScript Bytecode'
+  type: 'Intermediate'
+  url: 'https://royale.apache.org'
 ,
   name: 'Rust Compiler'
   source: 'Rust'
@@ -556,12 +568,6 @@
   type: 'Transpiler'
   url: 'http://haste-lang.org'
 ,
-  name: 'Haxe ActionScript Compiler'
-  source: 'Haxe'
-  target: 'ActionScript'
-  type: 'Transpiler'
-  url: 'https://haxe.org/'
-,
   name: 'Haxe C# Compiler'
   source: 'Haxe'
   target: 'C#'
@@ -705,6 +711,12 @@
   target: 'C++'
   type: 'Transpiler'
   url: 'https://github.com/serge-sans-paille/pythran'
+,
+  name: 'Royale JavaScript Compiler'
+  source: 'ActionScript'
+  target: 'JavaScript'
+  type: 'Transpiler'
+  url: 'https://royale.apache.org'
 ,
   name: 'Scala.js'
   source: 'Scala'


### PR DESCRIPTION
Apache Royale compiles to ActionScript bytecode (ABC) for Flash Player, transpiles to JavaScript

Haxe ActionScript compilation goes to ActionScript bytecode, it is not a source-to-source translation (though there is an option)