### PR TITLE
README: contribution instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Contributing
 This list aims to be comprehensive while at the same time not populated with
 unused or defunct compilers. Similarly, the source or target language of any
 compiler should be either widely used or if it is an intermediate
-representation, must be accepted or targeted by other compilers. If a compiler
-is missing from the list that satisfies this criteria, feel free to create a
-pull request.
+representation, it must be accepted or targeted by other compilers.
+
+If a compiler is missing from the list that satisfies this criteria,
+feel free to create a pull request, by editing the
+[src/compilers.coffee](https://github.com/mohd-akram/compilers/blob/master/src/compilers.coffee)
+file. Make sure to place the new entry in alphabetical order
+within the appropriate section: Assembler, Intermediate, JIT, Native, or Transpiler
+(see the existing entries to get a feel of where the new entry fits best).


### PR DESCRIPTION
By the way, I think the types (Assembler, Intermediate, JIT, Native, Transpiler) should be clarified. Ideally we should have a description for each of them that captures the key properties shared by all entries of that category. Such a description could be captured both on the README, and as comments in the compilers.coffee file.