### PR TITLE
Add Eta, that enables Haskell on the JVM

### DIFF
--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -85,6 +85,12 @@
   type: 'Intermediate'
   url: 'https://crystal-lang.org/'
 ,
+  name: 'Eta Compiler',
+  source: 'Haskell',
+  target: 'Java Bytecode',
+  type: 'Intermediate',
+  url: 'https://eta-lang.org/'
+,
   name: 'Flang'
   source: 'Fortran'
   target: 'LLVM IR'


### PR DESCRIPTION
Eta is described as "a dialect of Haskell which runs on the JVM". It is fully compatible with GHC 7.10.3's Haskell and therefore, I added it as a "compiler", since it enables to run Haskell on the JVM.