### PR TITLE
Add zig

### DIFF
--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -766,4 +766,16 @@
   type: 'Transpiler'
   url: 'https://wiki.gnome.org/Projects/Vala'
 ,
+  name: 'Zig'
+  source: 'Zig'
+  target: 'LLVM IR'
+  type: 'Intermediate'
+  url: 'https://ziglang.org/'
+,
+  name: 'Zig C Compiler'
+  source: 'C'
+  target: 'LLVM IR'
+  type: 'Intermediate'
+  url: 'https://ziglang.org/'
+,
 ]


### PR DESCRIPTION
Note that Zig is moving away from LLVM, LLD, and Clang libraries
- https://github.com/ziglang/zig/issues/16270